### PR TITLE
补充安装gbase到maven的脚本

### DIFF
--- a/jars/readme.md
+++ b/jars/readme.md
@@ -14,6 +14,8 @@ gbase：[下载](gbase-8.3.81.53.jar)
 mvn install:install-file -DgroupId=com.ibm.db2 -DartifactId=db2jcc -Dversion=3.72.44 -Dpackaging=jar -Dfile=db2jcc-3.72.44.jar
 
 mvn install:install-file -DgroupId=com.github.noraui -DartifactId=ojdbc8 -Dversion=12.2.0.1 -Dpackaging=jar -Dfile=ojdbc8-12.2.0.1.jar
+
+mvn install:install-file -DgroupId=com.esen.jdbc -DartifactId=gbase -Dversion=8.3.81.53 -Dpackaging=jar -Dfile=gbase-8.3.81.53.jar
 ```
 
 说明：这两个驱动包在我们自己搭建的仓库里有，并且这两个版本的驱动包在已经在生产环境中使用，所以不能很快修改版本，需要做相关测试，我们会在后期的版本中修改这两个驱动包的版本，可以先暂时下载安装驱动来解决。


### PR DESCRIPTION
补充安装gbase到maven的脚本.是否可以把这个页面内容在首页提及下
给个连接到这个页面/或者加个安装模块说明提及下.
,我也是下载install找不到这几个jar.才到项目issues里搜到了这个解答.